### PR TITLE
Add versions to mac and cipher streams.

### DIFF
--- a/instrumentTest/crypto/src/com/facebook/crypto/BouncyCastleHelper.java
+++ b/instrumentTest/crypto/src/com/facebook/crypto/BouncyCastleHelper.java
@@ -27,7 +27,7 @@ import org.spongycastle.crypto.params.KeyParameter;
 @TargetApi(Build.VERSION_CODES.GINGERBREAD)
 public class BouncyCastleHelper {
 
-  public static Result bouncyCastleEncrypt(byte[] data, byte[] key, byte[] iv, Entity entity)
+  public static Result bouncyCastleEncrypt(byte[] data, byte[] key, byte[] iv, byte[] aadData)
       throws UnsupportedEncodingException, InvalidCipherTextException {
     GCMBlockCipher gcm = new GCMBlockCipher(new AESEngine());
     byte[] gcmOut = new byte[CryptoTestUtils.NUM_DATA_BYTES + NativeGCMCipher.TAG_LENGTH];
@@ -38,7 +38,7 @@ public class BouncyCastleHelper {
           keyParameter,
           NativeGCMCipher.TAG_LENGTH * 8,
           iv,
-          entity.getBytes());
+          aadData);
 
     // Init encryption.
     gcm.init(true, params);

--- a/instrumentTest/crypto/src/com/facebook/crypto/CryptoSerializerHelper.java
+++ b/instrumentTest/crypto/src/com/facebook/crypto/CryptoSerializerHelper.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+package com.facebook.crypto;
+
+import com.facebook.crypto.cipher.NativeGCMCipher;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+
+/**
+ * Helper functions for tests to serialize and de-serialize crypto data.
+ */
+public class CryptoSerializerHelper {
+
+  public static byte[] cipherText(byte[] cipheredData) {
+    return Arrays.copyOfRange(cipheredData,
+        NativeGCMCipher.IV_LENGTH + 2,
+        cipheredData.length - NativeGCMCipher.TAG_LENGTH);
+  }
+
+  public static byte[] tag(byte[] cipheredData) {
+    return Arrays.copyOfRange(cipheredData,
+        cipheredData.length - NativeGCMCipher.TAG_LENGTH,
+        cipheredData.length);
+  }
+
+  public static byte[] createCipheredData(byte[] iv, byte[] cipherText, byte[] tag) throws IOException {
+    ByteArrayOutputStream cipheredData = new ByteArrayOutputStream();
+    cipheredData.write(VersionCodes.CIPHER_SERALIZATION_VERSION);
+    cipheredData.write(VersionCodes.CIPHER_ID);
+    cipheredData.write(iv);
+    cipheredData.write(cipherText);
+    cipheredData.write(tag);
+    return cipheredData.toByteArray();
+  }
+
+  public static byte[] createMacData(byte[] data, byte[] macBytes) throws IOException {
+    ByteArrayOutputStream dataWithMac = new ByteArrayOutputStream();
+    dataWithMac.write(VersionCodes.MAC_SERIALIZATION_VERSION);
+    dataWithMac.write(VersionCodes.MAC_ID);
+    dataWithMac.write(data);
+    dataWithMac.write(macBytes);
+    return  dataWithMac.toByteArray();
+  }
+
+  public static byte[] getMacTag(byte[] macData, int macLength) {
+    return Arrays.copyOfRange(macData, macData.length - macLength, macData.length);
+  }
+
+  public static byte[] getOriginalDataFromMacData(byte[] macData, int macLength) {
+    return Arrays.copyOfRange(macData, 2, macData.length - macLength);
+  }
+
+  /**
+   * This method mixes in the crypto serialization version as well as the ID of either the cipher or mac
+   * into the authenticated bytes to prevent cross-protocol attacks, i.e. if we don't authenticate
+   * this data, we could be forced to use a construction using the parameters of some other
+   * construction.
+   */
+  public static byte[] computeBytesToAuthenticate(byte[] entityBytes, byte cryptoVersion, byte cryptoId) {
+    int entityLength = entityBytes.length;
+    byte[] aadBytes = new byte[entityLength + 2];
+    aadBytes[0] = cryptoVersion;
+    aadBytes[1] = cryptoId;
+    System.arraycopy(entityBytes, 0, aadBytes, 2, entityLength);
+    return aadBytes;
+  }
+}

--- a/java/com/facebook/crypto/VersionCodes.java
+++ b/java/com/facebook/crypto/VersionCodes.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+package com.facebook.crypto;
+
+/**
+ * Represents the current versions and IDs of the crypto operations.
+ */
+/* package */ class VersionCodes {
+
+  /**
+   * Identifier of the cipher serialization version.
+   */
+  public static final byte CIPHER_SERALIZATION_VERSION = 1;
+
+  /**
+   * Identifier for the cipher algorithm and the framing method used.
+   */
+  public static final byte CIPHER_ID = 1;
+
+  /**
+   * Identifier for the mac serialization version.
+   */
+  public static final byte MAC_SERIALIZATION_VERSION = 1;
+
+  /**
+   * Identifier for the mac algorithm and the framing method used.
+   */
+  public static final byte MAC_ID = 1;
+}

--- a/java/com/facebook/crypto/util/Assertions.java
+++ b/java/com/facebook/crypto/util/Assertions.java
@@ -10,6 +10,8 @@
 
 package com.facebook.crypto.util;
 
+import java.io.IOException;
+
 /**
  * Adaptation of certain methods required by us so that we don't have
  * to introduce a dependency on guava.
@@ -19,6 +21,12 @@ public class Assertions {
   public static void checkState(boolean expression, String errorMessage) {
     if (!expression) {
       throw new IllegalStateException(String.valueOf(errorMessage));
+    }
+  }
+
+  public static void checkArgumentForIO(boolean expression, String errorMessage) throws IOException {
+    if (!expression) {
+      throw new IOException(errorMessage);
     }
   }
 }


### PR DESCRIPTION
Currently the mac and cipher streams do not maintain versioning
of their own but rely on higher layers for verisioning.

However some apps could store data persistently and not having
versioning might make it difficult for apps to upgrade libs.

This adds 2 version numbers to macs and ciphers
1. CIPHER_SERIALIZATION_VERSION / MAC_\* : Determines the wire format of
the rest of the message
2. CIPHER_ID / MAC_ID: Determines the id of the encryption algorithm
used + the framing format for the algorithm.

We also add authentication of the IDs to protect against cross-protocol
attacks if algorithms are changed in the future.

Test Plan:
Ran both the unit tests and the integration tests.
They both pass with flying colors.
