### PR TITLE
Add support for write(byte)

### DIFF
--- a/instrumentTest/crypto/src/com/facebook/crypto/NativeGCMCipherOutputStreamTest.java
+++ b/instrumentTest/crypto/src/com/facebook/crypto/NativeGCMCipherOutputStreamTest.java
@@ -116,4 +116,24 @@ public class NativeGCMCipherOutputStreamTest extends InstrumentationTestCase {
         expectedEncryptedString,
         encryptedString);
   }
+
+  public void testEncryptedDataIsExpectedWhenWrittenOneByteAtATime() throws Exception {
+    String dataToEncrypt = "data to encrypt";
+    String expectedEncryptedString = "69VhniqXP+xA0CcKJFx5";
+    OutputStream outputStream = mCrypto.getCipherOutputStream(
+      mCipherOutputStream,
+      new Entity(CryptoTestUtils.ENTITY_NAME));
+
+    byte[] inputData = dataToEncrypt.getBytes("UTF-8");
+    for (byte inputByte : inputData) {
+      outputStream.write(inputByte);
+    }
+    outputStream.close();
+    byte[] encryptedData = CryptoSerializerHelper.cipherText(mCipherOutputStream.toByteArray());
+
+    String encryptedString = Base64.encodeToString(encryptedData, Base64.DEFAULT).trim();
+    assertEquals(CryptoTestUtils.ENCRYPTED_DATA_IS_DIFFERENT,
+      expectedEncryptedString,
+      encryptedString);
+  }
 }

--- a/java/com/facebook/crypto/streams/NativeGCMCipherOutputStream.java
+++ b/java/com/facebook/crypto/streams/NativeGCMCipherOutputStream.java
@@ -90,6 +90,8 @@ public class NativeGCMCipherOutputStream extends OutputStream {
 
   @Override
   public void write(int oneByte) throws IOException {
-    throw new UnsupportedOperationException();
+    byte[] data = new byte[1];
+    data[0] = (byte) oneByte;
+    write(data, 0, 1);
   }
 }


### PR DESCRIPTION
Summary:
A bunch of IO streams call the more
inefficient write(byte) operation.
We should support it.

Test Plan:
Ran integration tests.
