### PR TITLE
Add data to mac before writing out the stream

### DIFF
--- a/java/com/facebook/crypto/streams/NativeMacLayeredOutputStream.java
+++ b/java/com/facebook/crypto/streams/NativeMacLayeredOutputStream.java
@@ -57,13 +57,13 @@ public class NativeMacLayeredOutputStream extends OutputStream {
 
   @Override
   public void write(byte[] buffer, int offset, int count) throws IOException {
-    mOutputDelegate.write(buffer, offset, count);
     mMac.update(buffer, offset, count);
+    mOutputDelegate.write(buffer, offset, count);
   }
 
   @Override
   public void write(int oneByte) throws IOException {
-    mOutputDelegate.write(oneByte);
     mMac.update((byte) oneByte);
+    mOutputDelegate.write(oneByte);
   }
 }


### PR DESCRIPTION
Summary:
Writes data to the mac before writing out to
the stream.

This makes it more secure in presence of bugs
which partially write bytes to disk.

Test Plan:
integration tests.
