### PR TITLE
Fix NPE in destroyKeys()

### DIFF
--- a/java/com/facebook/android/crypto/keychain/SharedPrefsBackedKeyChain.java
+++ b/java/com/facebook/android/crypto/keychain/SharedPrefsBackedKeyChain.java
@@ -87,8 +87,12 @@ public class SharedPrefsBackedKeyChain implements KeyChain {
   public synchronized void destroyKeys() {
     mSetCipherKey = false;
     mSetMacKey = false;
-    Arrays.fill(mCipherKey, (byte) 0);
-    Arrays.fill(mMacKey, (byte) 0);
+    if (mCipherKey != null) {
+      Arrays.fill(mCipherKey, (byte) 0);
+    }
+    if (mMacKey != null) {
+      Arrays.fill(mMacKey, (byte) 0);
+    }
     mCipherKey = null;
     mMacKey = null;
     SharedPreferences.Editor editor = mSharedPreferences.edit();


### PR DESCRIPTION
destroyKeys() in SharedPrefsBackedKeyChain currently assumes that both getMacKey() and getCipherKey() had been called before. This is not always the case, e.g., when not having used crypto after starting the app or when either using enc/dec or integration checking.