### PR TITLE
Redundant method call

### DIFF
--- a/java/com/facebook/crypto/util/Assertions.java
+++ b/java/com/facebook/crypto/util/Assertions.java
@@ -20,7 +20,7 @@ public class Assertions {
 
   public static void checkState(boolean expression, String errorMessage) {
     if (!expression) {
-      throw new IllegalStateException(String.valueOf(errorMessage));
+      throw new IllegalStateException(errorMessage);
     }
   }
 


### PR DESCRIPTION
String.valueOf(String) returns exactly the same String object. Removed the redundant method call. 