### PR TITLE
Add Travis CI configuration for integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+language: android
+
+android:
+  components:
+    # Uncomment the lines below if you want to
+    # use the latest revision of Android SDK Tools
+    # - platform-tools
+    # - tools
+
+    # The BuildTools version used by your project
+    - build-tools-16.0.0
+
+    # The SDK version used to compile your project
+    - android-16
+
+    # Additional components
+    - extra-google-google_play_services
+    - extra-google-m2repository
+    - extra-android-m2repository
+    - addon-google_apis-google-16
+
+    # Specify at least one system image,
+    # if you need to run emulator(s) during your tests
+    - sys-img-armeabi-v7a-android-19
+    - sys-img-x86-android-17
+
+before_install:
+  - . .travis/install-ndk
+  - . .travis/install-buck
+  - PATH=`pwd`/buck/bin:$PATH
+  - export PATH
+  # Emulator Management: Create, Start and Wait
+  - echo no | android create avd --force -n test -t android-19 --abi armeabi-v7a
+  - emulator -avd test -no-audio -no-window &
+  - android-wait-for-emulator
+  - adb shell input keyevent 82 &
+
+script: instrumentTest/crypto/run 
+

--- a/.travis/install-buck
+++ b/.travis/install-buck
@@ -1,0 +1,24 @@
+#!/bin/sh
+echo Installing BUCK dependencies
+
+sudo apt-get install default-jre
+sudo apt-get install openjdk-7-jdk
+sudo apt-get install ant
+
+echo Downloading BUCK
+
+git clone https://github.com/facebook/buck.git  
+
+echo Building BUCK
+cd buck  
+ant  
+
+echo Running BUCK for the first time
+./bin/buck --help
+cd ..
+
+echo Adding BUCK to the path
+PATH=`pwd`/buck/bin:$PATH
+export PATH
+
+echo BUCK installed on `which buck` 

--- a/.travis/install-ndk
+++ b/.travis/install-ndk
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Get Android NDK
+echo Downloading NDK...
+wget http://dl.google.com/android/ndk/android-ndk-r10e-linux-x86_64.bin -O ndk.bin
+chmod a+x ndk.bin
+echo Installing NDK...
+./ndk.bin 1> /dev/null 2>&1
+ANDROID_NDK=`pwd`/android-ndk-r10e/
+export ANDROID_NDK
+echo NDK installed on $ANDROID_NDK


### PR DESCRIPTION
This 3 files (the main one being `.travis.yml`) are what we need to make Travis CI to run the integration tests: `integrationTest/crypto/run`

I already configured Travis CI on my fork and it's working fine.

Alternatively: the admin could enable Travis CI before merging this request... and when landing it will be run for the first time on facebook/conceal repo.