### PR TITLE
Decrypt stream content on the same buffer

### DIFF
--- a/benchmarks/src/com/facebook/crypto/benchmarks/cipher/NativeGCMCipherHelper.java
+++ b/benchmarks/src/com/facebook/crypto/benchmarks/cipher/NativeGCMCipherHelper.java
@@ -43,13 +43,13 @@ public class NativeGCMCipherHelper {
     return new NativeGCMCipherHelper(key, iv);
   }
 
-  public OutputStream getOutputStream(OutputStream cipherStream)
+  public OutputStream getOutputStream(OutputStream cipherStream, byte[] encryptBuffer)
       throws IOException, CryptoInitializationException {
     NativeGCMCipher gcmCipher = new NativeGCMCipher(mNativeCryptoLibrary);
     gcmCipher.encryptInit(mKey, mIv);
     cipherStream.write(mIv);
 
-    return new NativeGCMCipherOutputStream(cipherStream, gcmCipher);
+    return new NativeGCMCipherOutputStream(cipherStream, gcmCipher, encryptBuffer);
   }
 
   public InputStream getInputStream(InputStream cipherStream)

--- a/instrumentTest/crypto/src/com/facebook/crypto/NativeGCMCipherOutputStreamTest.java
+++ b/instrumentTest/crypto/src/com/facebook/crypto/NativeGCMCipherOutputStreamTest.java
@@ -101,7 +101,23 @@ public class NativeGCMCipherOutputStreamTest extends InstrumentationTestCase {
     assertTrue(CryptoTestUtils.DATA_IS_NOT_ENCRYPTED, !Arrays.equals(mData, encryptedData));
   }
 
-  public void testEncryptedDataIsExpected() throws Exception {
+  public void testWriteDataUsingOffsetsAndPreallocatedBuffer() throws Exception {
+      OutputStream outputStream = mCrypto.getCipherOutputStream(
+          mCipherOutputStream,
+          new Entity(CryptoTestUtils.ENTITY_NAME),
+              new byte[1200]);
+      outputStream.write(mData, 0, mData.length / 2);
+      outputStream.write(mData, mData.length / 2, mData.length / 2 + mData.length % 2);
+      outputStream.close();
+      byte[] encryptedData = CryptoSerializerHelper.cipherText(mCipherOutputStream.toByteArray());
+
+      assertTrue(CryptoTestUtils.ENCRYPTED_DATA_NULL, encryptedData != null);
+      assertTrue(CryptoTestUtils.ENCRYPTED_DATA_OF_DIFFERENT_LENGTH,
+          encryptedData.length == mData.length);
+      assertTrue(CryptoTestUtils.DATA_IS_NOT_ENCRYPTED, !Arrays.equals(mData, encryptedData));
+    }
+
+    public void testEncryptedDataIsExpected() throws Exception {
     String dataToEncrypt = "data to encrypt";
     String expectedEncryptedString = "69VhniqXP+xA0CcKJFx5";
     OutputStream outputStream = mCrypto.getCipherOutputStream(

--- a/java/com/facebook/crypto/CipherHelper.java
+++ b/java/com/facebook/crypto/CipherHelper.java
@@ -27,7 +27,7 @@ import java.io.OutputStream;
     mNativeCryptoLibrary = nativeCryptoLibrary;
   }
 
-  public OutputStream getCipherOutputStream(OutputStream cipherStream, Entity entity)
+  public OutputStream getCipherOutputStream(OutputStream cipherStream, Entity entity, byte[] encryptBuffer)
     throws KeyChainException, CryptoInitializationException, IOException {
 
     cipherStream.write(VersionCodes.CIPHER_SERALIZATION_VERSION);
@@ -40,7 +40,7 @@ import java.io.OutputStream;
 
     byte[] entityBytes = entity.getBytes();
     computeCipherAad(gcmCipher, VersionCodes.CIPHER_SERALIZATION_VERSION, VersionCodes.CIPHER_ID, entityBytes);
-    return new NativeGCMCipherOutputStream(cipherStream, gcmCipher);
+    return new NativeGCMCipherOutputStream(cipherStream, gcmCipher, encryptBuffer);
   }
 
   /**

--- a/java/com/facebook/crypto/Crypto.java
+++ b/java/com/facebook/crypto/Crypto.java
@@ -49,17 +49,27 @@ public class Crypto {
   }
 
   /**
+   * Invokes getCipherOutputStream(cipherStream, entity, null)
+   */
+  public OutputStream getCipherOutputStream(OutputStream cipherStream, Entity entity)
+          throws IOException, CryptoInitializationException, KeyChainException {
+    return getCipherOutputStream(cipherStream, entity, null);
+  }
+
+  /**
    * Gives you an output stream wrapper that encrypts the text written.
    *
    * @param cipherStream The stream that the encrypted data will be written to.
    * @param entity A unique object identifying what is being written.
+   * @param encryptBuffer an auxiliar buffer used to encrypt the content
+   *                      if null a new one will be created (size: 256+tagSize)
    *
    * @return A ciphered output stream to write to.
    * @throws IOException
    */
-  public OutputStream getCipherOutputStream(OutputStream cipherStream, Entity entity)
+  public OutputStream getCipherOutputStream(OutputStream cipherStream, Entity entity, byte[] encryptBuffer)
       throws IOException, CryptoInitializationException, KeyChainException {
-    return mCipherHelper.getCipherOutputStream(cipherStream, entity);
+    return mCipherHelper.getCipherOutputStream(cipherStream, entity, encryptBuffer);
   }
 
   /**
@@ -99,7 +109,7 @@ public class Crypto {
     throws KeyChainException, CryptoInitializationException, IOException {
     int cipheredBytesLength = plainTextBytes.length + mCipherHelper.getCipherMetaDataLength();
     FixedSizeByteArrayOutputStream outputStream = new FixedSizeByteArrayOutputStream(cipheredBytesLength);
-    OutputStream cipherStream = mCipherHelper.getCipherOutputStream(outputStream, entity);
+    OutputStream cipherStream = mCipherHelper.getCipherOutputStream(outputStream, entity, null);
     cipherStream.write(plainTextBytes);
     cipherStream.close();
     return outputStream.getBytes();

--- a/java/com/facebook/crypto/cipher/NativeGCMCipher.java
+++ b/java/com/facebook/crypto/cipher/NativeGCMCipher.java
@@ -67,10 +67,10 @@ public class NativeGCMCipher {
     mCurrentState = STATE.DECRYPT_INITIALIZED;
   }
 
-  public int update(byte[] data, int offset, int dataLen, byte[] output)
+  public int update(byte[] data, int offset, int dataLen, byte[] output, int outputOffset)
       throws NativeGCMCipherException {
     ensureInInitalizedState();
-    int bytesRead = nativeUpdate(data, offset, dataLen, output);
+    int bytesRead = nativeUpdate(data, offset, dataLen, output, outputOffset);
     if (bytesRead < 0) {
       throw new NativeGCMCipherException(
           formatStrLocaleSafe(
@@ -152,7 +152,7 @@ public class NativeGCMCipher {
   private native int nativeEncryptInit(byte[] key, byte[] iv);
   private native int nativeDecryptInit(byte[] key, byte[] iv);
 
-  private native int nativeUpdate(byte[] data, int offset, int dataLen, byte[] output);
+  private native int nativeUpdate(byte[] data, int offset, int dataLen, byte[] output, int outputOffset);
   private native int nativeUpdateAad(byte[] data, int dataLength);
 
   private native int nativeEncryptFinal(byte[] tag, int tagLen);

--- a/java/com/facebook/crypto/streams/NativeGCMCipherInputStream.java
+++ b/java/com/facebook/crypto/streams/NativeGCMCipherInputStream.java
@@ -10,10 +10,10 @@
 
 package com.facebook.crypto.streams;
 
+import com.facebook.crypto.cipher.NativeGCMCipher;
+
 import java.io.IOException;
 import java.io.InputStream;
-
-import com.facebook.crypto.cipher.NativeGCMCipher;
 
 /**
  * This class is used to encapsulate decryption using GCM. On reads, bytes are first read from the
@@ -92,26 +92,9 @@ public class NativeGCMCipherInputStream extends InputStream {
       return -1;
     }
 
-    int times = read / UPDATE_BUFFER_SIZE;
-    int remainder = read % UPDATE_BUFFER_SIZE;
+    read = mCipher.update(buffer, offset, read, buffer, offset);
 
-    int originalOffset = offset;
-    int currentReadOffset = offset;
-
-    for (int i = 0; i < times; ++i) {
-      int bytesDecrypted = mCipher.update(buffer, offset, UPDATE_BUFFER_SIZE, mUpdateBuffer);
-      System.arraycopy(mUpdateBuffer, 0, buffer, currentReadOffset, bytesDecrypted);
-      currentReadOffset += bytesDecrypted;
-      offset += UPDATE_BUFFER_SIZE;
-    }
-
-    if (remainder > 0) {
-      int bytesDecrypted = mCipher.update(buffer, offset, remainder, mUpdateBuffer);
-      System.arraycopy(mUpdateBuffer, 0, buffer, currentReadOffset, bytesDecrypted);
-      currentReadOffset += bytesDecrypted;
-    }
-
-    return currentReadOffset - originalOffset;
+    return read;
   }
 
   private void ensureTagValid() throws IOException {

--- a/java/com/facebook/crypto/streams/NativeGCMCipherOutputStream.java
+++ b/java/com/facebook/crypto/streams/NativeGCMCipherOutputStream.java
@@ -87,13 +87,13 @@ public class NativeGCMCipherOutputStream extends OutputStream {
     int remainder = count % UPDATE_BUFFER_SIZE;
 
     for (int i = 0; i < times; ++i) {
-      int written = mCipher.update(buffer, offset, UPDATE_BUFFER_SIZE, mUpdateBuffer);
+      int written = mCipher.update(buffer, offset, UPDATE_BUFFER_SIZE, mUpdateBuffer, 0);
       mCipherDelegate.write(mUpdateBuffer, 0, written);
       offset += UPDATE_BUFFER_SIZE;
     }
 
     if (remainder > 0) {
-      int written = mCipher.update(buffer, offset, remainder, mUpdateBuffer);
+      int written = mCipher.update(buffer, offset, remainder, mUpdateBuffer, 0);
       mCipherDelegate.write(mUpdateBuffer, 0, written);
     }
   }

--- a/java/com/facebook/crypto/streams/NativeGCMCipherOutputStream.java
+++ b/java/com/facebook/crypto/streams/NativeGCMCipherOutputStream.java
@@ -22,7 +22,7 @@ import java.lang.ArrayIndexOutOfBoundsException;
  */
 public class NativeGCMCipherOutputStream extends OutputStream {
 
-  private static final int UPDATE_BUFFER_SIZE = 256;
+  private static final int DEFAULT_ENCRYPT_BUFFER_SIZE = 256;
 
   private final OutputStream mCipherDelegate;
   private final NativeGCMCipher mCipher;
@@ -37,11 +37,24 @@ public class NativeGCMCipherOutputStream extends OutputStream {
    * @param cipherDelegate The stream to write encrypted bytes to.
    * @param cipher The cipher used to encrypt the bytes.
    */
-  public NativeGCMCipherOutputStream(OutputStream cipherDelegate,
-      NativeGCMCipher cipher) {
+  public NativeGCMCipherOutputStream(
+          OutputStream cipherDelegate,
+          NativeGCMCipher cipher,
+          byte[] encryptBuffer) {
     mCipherDelegate = cipherDelegate;
     mCipher = cipher;
-    mUpdateBuffer = new byte[UPDATE_BUFFER_SIZE + mCipher.getCipherBlockSize()];
+
+    // use encryptBuffer or create a new one
+    int cipherBlockSize = mCipher.getCipherBlockSize();
+    if (encryptBuffer == null) {
+      encryptBuffer = new byte[DEFAULT_ENCRYPT_BUFFER_SIZE + cipherBlockSize];
+    } else {
+      int minSize = cipherBlockSize + 1;
+      if (encryptBuffer.length < minSize) {
+        throw new IllegalArgumentException("encryptBuffer cannot be smaller than " + minSize + "B");
+      }
+    }
+    mUpdateBuffer = encryptBuffer;
   }
 
   @Override
@@ -83,13 +96,13 @@ public class NativeGCMCipherOutputStream extends OutputStream {
       throw new ArrayIndexOutOfBoundsException(offset + count);
     }
 
-    int times = count / UPDATE_BUFFER_SIZE;
-    int remainder = count % UPDATE_BUFFER_SIZE;
+    int times = count / DEFAULT_ENCRYPT_BUFFER_SIZE;
+    int remainder = count % DEFAULT_ENCRYPT_BUFFER_SIZE;
 
     for (int i = 0; i < times; ++i) {
-      int written = mCipher.update(buffer, offset, UPDATE_BUFFER_SIZE, mUpdateBuffer, 0);
+      int written = mCipher.update(buffer, offset, DEFAULT_ENCRYPT_BUFFER_SIZE, mUpdateBuffer, 0);
       mCipherDelegate.write(mUpdateBuffer, 0, written);
-      offset += UPDATE_BUFFER_SIZE;
+      offset += DEFAULT_ENCRYPT_BUFFER_SIZE;
     }
 
     if (remainder > 0) {

--- a/native/crypto/gcm.c
+++ b/native/crypto/gcm.c
@@ -95,7 +95,8 @@ JNIEXPORT int JNICALL Java_com_facebook_crypto_cipher_NativeGCMCipher_nativeUpda
   jbyteArray data,
   jint offset,
   jint dataLength,
-  jbyteArray output) {
+  jbyteArray output,
+  jint outputOffset) {
 
   int bytesWritten = 0;
   EVP_CIPHER_CTX* ctx = Get_Cipher_CTX(env, obj);
@@ -114,7 +115,7 @@ JNIEXPORT int JNICALL Java_com_facebook_crypto_cipher_NativeGCMCipher_nativeUpda
     return CRYPTO_NO_BYTES_WRITTEN;
   }
 
-  if (!EVP_CipherUpdate(ctx, outputBytes, &bytesWritten, dataBytes + offset, dataLength)) {
+  if (!EVP_CipherUpdate(ctx, outputBytes + outputOffset, &bytesWritten, dataBytes + offset, dataLength)) {
     bytesWritten = CRYPTO_NO_BYTES_WRITTEN;
   }
 


### PR DESCRIPTION
Changes:
- nativeUpdate accepts an offset for the output too
- InputStream.read(byte[]) uses only one call to native with the whole byte[], using it as both source and target of the decryption, as decryption uses exactly the same bytes.