### PR TITLE
Fix encryption stream chunk size when using a provided buffer

### DIFF
--- a/instrumentTest/crypto/src/com/facebook/crypto/NativeGCMCipherOutputStreamTest.java
+++ b/instrumentTest/crypto/src/com/facebook/crypto/NativeGCMCipherOutputStreamTest.java
@@ -101,23 +101,31 @@ public class NativeGCMCipherOutputStreamTest extends InstrumentationTestCase {
     assertTrue(CryptoTestUtils.DATA_IS_NOT_ENCRYPTED, !Arrays.equals(mData, encryptedData));
   }
 
-  public void testWriteDataUsingOffsetsAndPreallocatedBuffer() throws Exception {
-      OutputStream outputStream = mCrypto.getCipherOutputStream(
-          mCipherOutputStream,
-          new Entity(CryptoTestUtils.ENTITY_NAME),
-              new byte[1200]);
-      outputStream.write(mData, 0, mData.length / 2);
-      outputStream.write(mData, mData.length / 2, mData.length / 2 + mData.length % 2);
-      outputStream.close();
-      byte[] encryptedData = CryptoSerializerHelper.cipherText(mCipherOutputStream.toByteArray());
+  public void testWriteDataUsingOffsetsAndPreallocatedSmallBuffer() throws Exception {
+      testWriteDataUsingOffsetsAndPreallocatedBuffer(100);
+  }
 
-      assertTrue(CryptoTestUtils.ENCRYPTED_DATA_NULL, encryptedData != null);
-      assertTrue(CryptoTestUtils.ENCRYPTED_DATA_OF_DIFFERENT_LENGTH,
-          encryptedData.length == mData.length);
-      assertTrue(CryptoTestUtils.DATA_IS_NOT_ENCRYPTED, !Arrays.equals(mData, encryptedData));
-    }
+  public void testWriteDataUsingOffsetsAndPreallocatedBigBuffer() throws Exception {
+      testWriteDataUsingOffsetsAndPreallocatedBuffer(1200);
+  }
 
-    public void testEncryptedDataIsExpected() throws Exception {
+  private void testWriteDataUsingOffsetsAndPreallocatedBuffer(int bufferSize) throws Exception {
+    OutputStream outputStream = mCrypto.getCipherOutputStream(
+        mCipherOutputStream,
+        new Entity(CryptoTestUtils.ENTITY_NAME),
+            new byte[bufferSize]);
+    outputStream.write(mData, 0, mData.length / 2);
+    outputStream.write(mData, mData.length / 2, mData.length / 2 + mData.length % 2);
+    outputStream.close();
+    byte[] encryptedData = CryptoSerializerHelper.cipherText(mCipherOutputStream.toByteArray());
+
+    assertTrue(CryptoTestUtils.ENCRYPTED_DATA_NULL, encryptedData != null);
+    assertTrue(CryptoTestUtils.ENCRYPTED_DATA_OF_DIFFERENT_LENGTH,
+        encryptedData.length == mData.length);
+    assertTrue(CryptoTestUtils.DATA_IS_NOT_ENCRYPTED, !Arrays.equals(mData, encryptedData));
+  }
+
+  public void testEncryptedDataIsExpected() throws Exception {
     String dataToEncrypt = "data to encrypt";
     String expectedEncryptedString = "69VhniqXP+xA0CcKJFx5";
     OutputStream outputStream = mCrypto.getCipherOutputStream(


### PR DESCRIPTION
The encryption stream was changed to accept an external buffer to use for encryption. But the size of the chunk for writing was kept the same.

So:
- if provided buffer was bigger, no perf improvement happened anyway
- if provided buffer was smaller, an ArrayOutOfBoundsException was thrown

I added a test ...SmallPreallocatedBuffer to test the later case.
Before the fix it was red.
After the fix it's green.