### PR TITLE
FixedSecureRandom: encapsulate fix for Android unsecure random generator

### DIFF
--- a/instrumentTest/crypto/src/com/facebook/crypto/PasswordBasedKeyDerivationTest.java
+++ b/instrumentTest/crypto/src/com/facebook/crypto/PasswordBasedKeyDerivationTest.java
@@ -10,6 +10,7 @@
 
 package com.facebook.crypto;
 
+import com.facebook.android.crypto.keychain.FixedSecureRandom;
 import com.facebook.crypto.keygen.PasswordBasedKeyDerivation;
 import com.facebook.crypto.util.SystemNativeCryptoLibrary;
 
@@ -37,9 +38,10 @@ public class PasswordBasedKeyDerivationTest extends InstrumentationTestCase {
   }
 
   private void testOneCase(String password, String saltString, int iterations, int keyLength, String hexResult) throws Exception {
+    FixedSecureRandom secureRandom = new FixedSecureRandom();
     SystemNativeCryptoLibrary library = new SystemNativeCryptoLibrary();
     byte[] salt = saltString.getBytes("ASCII");
-    byte[] key = new PasswordBasedKeyDerivation(library)
+    byte[] key = new PasswordBasedKeyDerivation(secureRandom, library)
         .setPassword(password) // it converts to c-char* using UTF8 which is equal to ASCII for 0-127
         .setSalt(salt)
         .setIterations(iterations)

--- a/java/com/facebook/android/crypto/keychain/FixedSecureRandom.java
+++ b/java/com/facebook/android/crypto/keychain/FixedSecureRandom.java
@@ -1,0 +1,17 @@
+package com.facebook.android.crypto.keychain;
+
+import java.security.SecureRandom;
+
+/**
+ * Child implementation of SecureRandom that runs the needed fix before generating byte arrays.
+ * Client code should only use nextBytes (as it's the only method using the fix).
+ * {@see SecureRandomFix}
+ */
+public class FixedSecureRandom extends SecureRandom {
+
+    @Override
+    public synchronized void nextBytes(byte[] bytes) {
+        SecureRandomFix.tryApplyFixes();
+        super.nextBytes(bytes);
+    }
+}

--- a/java/com/facebook/android/crypto/keychain/SharedPrefsBackedKeyChain.java
+++ b/java/com/facebook/android/crypto/keychain/SharedPrefsBackedKeyChain.java
@@ -42,7 +42,7 @@ public class SharedPrefsBackedKeyChain implements KeyChain {
   /* package */ static final String MAC_KEY_PREF = "mac_key";
 
   private final SharedPreferences mSharedPreferences;
-  private final SecureRandom mSecureRandom;
+  private final FixedSecureRandom mSecureRandom;
 
   protected byte[] mCipherKey;
   protected boolean mSetCipherKey;
@@ -50,11 +50,9 @@ public class SharedPrefsBackedKeyChain implements KeyChain {
   protected byte[] mMacKey;
   protected boolean mSetMacKey;
 
-  private static final SecureRandomFix sSecureRandomFix = new SecureRandomFix();
-
   public SharedPrefsBackedKeyChain(Context context) {
     mSharedPreferences = context.getSharedPreferences(SHARED_PREF_NAME, Context.MODE_PRIVATE);
-    mSecureRandom = new SecureRandom();
+    mSecureRandom = new FixedSecureRandom();
   }
 
   @Override
@@ -77,7 +75,6 @@ public class SharedPrefsBackedKeyChain implements KeyChain {
 
   @Override
   public byte[] getNewIV() throws KeyChainException {
-    sSecureRandomFix.tryApplyFixes();
     byte[] iv = new byte[NativeGCMCipher.IV_LENGTH];
     mSecureRandom.nextBytes(iv);
     return iv;
@@ -115,7 +112,6 @@ public class SharedPrefsBackedKeyChain implements KeyChain {
   }
 
   private byte[] generateAndSaveKey(String pref, int length) throws KeyChainException {
-    sSecureRandomFix.tryApplyFixes();
     byte[] key = new byte[length];
     mSecureRandom.nextBytes(key);
     // Store the session key.

--- a/java/com/facebook/crypto/keygen/PasswordBasedKeyDerivation.java
+++ b/java/com/facebook/crypto/keygen/PasswordBasedKeyDerivation.java
@@ -52,6 +52,7 @@ public class PasswordBasedKeyDerivation {
   public static final int DEFAULT_KEY_LENGTH = 16;
 
   private final NativeCryptoLibrary mNativeLibrary;
+  private final SecureRandom mSecureRandom;
 
   private int mIterations;
   private String mPassword;
@@ -59,7 +60,12 @@ public class PasswordBasedKeyDerivation {
   private int mKeyLengthInBytes;
   private byte[] mGeneratedKey;
 
-  public PasswordBasedKeyDerivation(NativeCryptoLibrary library) {
+  /**
+   * @param secureRandom this will be used to generate the salt.
+   *                     Use FixedSecureRandom for Android, never java.util.SecureRandom.
+   */
+  public PasswordBasedKeyDerivation(SecureRandom secureRandom, NativeCryptoLibrary library) {
+    mSecureRandom = secureRandom;
     mNativeLibrary = library;
     mIterations = DEFAULT_ITERATIONS;
     mKeyLengthInBytes = DEFAULT_KEY_LENGTH;
@@ -103,7 +109,7 @@ public class PasswordBasedKeyDerivation {
     }
     if (mSalt == null) {
       mSalt = new byte[DEFAULT_SALT_LENGTH];
-      new SecureRandom().nextBytes(mSalt);
+      mSecureRandom.nextBytes(mSalt);
     }
     mGeneratedKey = new byte[mKeyLengthInBytes];
     mNativeLibrary.ensureCryptoLoaded();

--- a/native/crypto/gcm_util.c
+++ b/native/crypto/gcm_util.c
@@ -38,13 +38,14 @@ int Init_GCM(JNIEnv* env, jobject obj, jbyteArray key, jbyteArray iv, jint mode)
     return CRYPTO_FAILURE;
   }
 
+  jsize ivLength = (*env)->GetArrayLength(env, iv);
   jbyte* ivBytes = (*env)->GetByteArrayElements(env, iv, NULL);
   if (!ivBytes) {
     (*env)->ReleaseByteArrayElements(env, key, keyBytes, JNI_ABORT);
     return CRYPTO_FAILURE;
   }
 
-  GCM_JNI_CTX* ctx = Create_GCM_JNI_CTX(keyBytes, ivBytes);
+  GCM_JNI_CTX* ctx = Create_GCM_JNI_CTX(keyBytes, ivBytes, ivLength);
   Set_GCM_JNI_CTX(env, obj, ctx);
 
   (*env)->ReleaseByteArrayElements(env, key, keyBytes, JNI_ABORT);
@@ -64,7 +65,7 @@ int Init_GCM(JNIEnv* env, jobject obj, jbyteArray key, jbyteArray iv, jint mode)
   return CRYPTO_SUCCESS;
 }
 
-GCM_JNI_CTX* Create_GCM_JNI_CTX(jbyte* keyBytes, jbyte* ivBytes) {
+GCM_JNI_CTX* Create_GCM_JNI_CTX(jbyte* keyBytes, jbyte* ivBytes, jsize ivLength) {
   GCM_JNI_CTX* ctx = (GCM_JNI_CTX*) malloc(sizeof(GCM_JNI_CTX));
   if (!ctx) {
     return NULL;
@@ -91,8 +92,17 @@ GCM_JNI_CTX* Create_GCM_JNI_CTX(jbyte* keyBytes, jbyte* ivBytes) {
     return NULL;
   }
 
+  if (ivLength > GCM_IV_LENGTH_IN_BYTES) {
+    ivLength = GCM_IV_LENGTH_IN_BYTES;
+  }
+
   memcpy(ctx->key, keyBytes, GCM_KEY_LENGTH_IN_BYTES);
-  memcpy(ctx->iv, ivBytes, GCM_IV_LENGTH_IN_BYTES);
+  memcpy(ctx->iv, ivBytes, ivLength);
+  if (ivLength < GCM_IV_LENGTH_IN_BYTES) {
+    // pad IV with zeros if provided IV is smaller
+    // this will remove undefined behavior (which worked because the bytes were already the same)
+    memset(ctx->iv+ivLength, 0, GCM_IV_LENGTH_IN_BYTES-ivLength);
+  }
   return ctx;
 }
 

--- a/native/crypto/gcm_util.h
+++ b/native/crypto/gcm_util.h
@@ -17,7 +17,7 @@ void Init_GCM_CTX_Ptr_Field(JNIEnv* env);
 
 int Init_GCM(JNIEnv* env, jobject obj, jbyteArray key, jbyteArray iv, jint mode);
 
-GCM_JNI_CTX* Create_GCM_JNI_CTX(jbyte* keyBytes, jbyte* ivBytes);
+GCM_JNI_CTX* Create_GCM_JNI_CTX(jbyte* keyBytes, jbyte* ivBytes, jsize ivLength);
 
 GCM_JNI_CTX* Get_GCM_JNI_CTX(JNIEnv* env, jobject obj);
 


### PR DESCRIPTION
Instead of calling SecureRandomFix from every client code and then SecureRandom, we can use an instance of SecureRandom that already does that transparently.