### PR TITLE
Fix: last IV 4 bytes (from 16) were undefined (Java sent 12)

### DIFF
--- a/native/crypto/gcm_util.h
+++ b/native/crypto/gcm_util.h
@@ -17,7 +17,7 @@ void Init_GCM_CTX_Ptr_Field(JNIEnv* env);
 
 int Init_GCM(JNIEnv* env, jobject obj, jbyteArray key, jbyteArray iv, jint mode);
 
-GCM_JNI_CTX* Create_GCM_JNI_CTX(jbyte* keyBytes, jbyte* ivBytes);
+GCM_JNI_CTX* Create_GCM_JNI_CTX(jbyte* keyBytes, jbyte* ivBytes, jsize ivLength);
 
 GCM_JNI_CTX* Get_GCM_JNI_CTX(JNIEnv* env, jobject obj);
 


### PR DESCRIPTION
Now we are zeroing to avoid undefined behavior.
Obviously the solution is provide the correct amount of bytes.
That will be made in the changes needed to support several key sizes.