### PR TITLE
FixedSecureRandom: encapsulated fix for Android's SecureRandom

### DIFF
--- a/instrumentTest/crypto/src/com/facebook/crypto/PasswordBasedKeyDerivationTest.java
+++ b/instrumentTest/crypto/src/com/facebook/crypto/PasswordBasedKeyDerivationTest.java
@@ -10,6 +10,7 @@
 
 package com.facebook.crypto;
 
+import com.facebook.android.crypto.keychain.FixedSecureRandom;
 import com.facebook.crypto.keygen.PasswordBasedKeyDerivation;
 import com.facebook.crypto.util.SystemNativeCryptoLibrary;
 
@@ -37,9 +38,10 @@ public class PasswordBasedKeyDerivationTest extends InstrumentationTestCase {
   }
 
   private void testOneCase(String password, String saltString, int iterations, int keyLength, String hexResult) throws Exception {
+    FixedSecureRandom secureRandom = new FixedSecureRandom();
     SystemNativeCryptoLibrary library = new SystemNativeCryptoLibrary();
     byte[] salt = saltString.getBytes("ASCII");
-    byte[] key = new PasswordBasedKeyDerivation(library)
+    byte[] key = new PasswordBasedKeyDerivation(secureRandom, library)
         .setPassword(password) // it converts to c-char* using UTF8 which is equal to ASCII for 0-127
         .setSalt(salt)
         .setIterations(iterations)

--- a/java/com/facebook/android/crypto/keychain/FixedSecureRandom.java
+++ b/java/com/facebook/android/crypto/keychain/FixedSecureRandom.java
@@ -1,0 +1,17 @@
+package com.facebook.android.crypto.keychain;
+
+import java.security.SecureRandom;
+
+/**
+ * Child implementation of SecureRandom that runs the needed fix before generating byte arrays.
+ * Client code should only use nextBytes (as it's the only method using the fix).
+ * {@see SecureRandomFix}
+ */
+public class FixedSecureRandom extends SecureRandom {
+
+    @Override
+    public synchronized void nextBytes(byte[] bytes) {
+        SecureRandomFix.tryApplyFixes();
+        super.nextBytes(bytes);
+    }
+}

--- a/java/com/facebook/android/crypto/keychain/SharedPrefsBackedKeyChain.java
+++ b/java/com/facebook/android/crypto/keychain/SharedPrefsBackedKeyChain.java
@@ -42,7 +42,7 @@ public class SharedPrefsBackedKeyChain implements KeyChain {
   /* package */ static final String MAC_KEY_PREF = "mac_key";
 
   private final SharedPreferences mSharedPreferences;
-  private final SecureRandom mSecureRandom;
+  private final FixedSecureRandom mSecureRandom;
 
   protected byte[] mCipherKey;
   protected boolean mSetCipherKey;
@@ -50,11 +50,9 @@ public class SharedPrefsBackedKeyChain implements KeyChain {
   protected byte[] mMacKey;
   protected boolean mSetMacKey;
 
-  private static final SecureRandomFix sSecureRandomFix = new SecureRandomFix();
-
   public SharedPrefsBackedKeyChain(Context context) {
     mSharedPreferences = context.getSharedPreferences(SHARED_PREF_NAME, Context.MODE_PRIVATE);
-    mSecureRandom = new SecureRandom();
+    mSecureRandom = new FixedSecureRandom();
   }
 
   @Override
@@ -77,7 +75,6 @@ public class SharedPrefsBackedKeyChain implements KeyChain {
 
   @Override
   public byte[] getNewIV() throws KeyChainException {
-    sSecureRandomFix.tryApplyFixes();
     byte[] iv = new byte[NativeGCMCipher.IV_LENGTH];
     mSecureRandom.nextBytes(iv);
     return iv;
@@ -115,7 +112,6 @@ public class SharedPrefsBackedKeyChain implements KeyChain {
   }
 
   private byte[] generateAndSaveKey(String pref, int length) throws KeyChainException {
-    sSecureRandomFix.tryApplyFixes();
     byte[] key = new byte[length];
     mSecureRandom.nextBytes(key);
     // Store the session key.

--- a/java/com/facebook/crypto/keygen/PasswordBasedKeyDerivation.java
+++ b/java/com/facebook/crypto/keygen/PasswordBasedKeyDerivation.java
@@ -52,6 +52,7 @@ public class PasswordBasedKeyDerivation {
   public static final int DEFAULT_KEY_LENGTH = 16;
 
   private final NativeCryptoLibrary mNativeLibrary;
+  private final SecureRandom mSecureRandom;
 
   private int mIterations;
   private String mPassword;
@@ -59,7 +60,12 @@ public class PasswordBasedKeyDerivation {
   private int mKeyLengthInBytes;
   private byte[] mGeneratedKey;
 
-  public PasswordBasedKeyDerivation(NativeCryptoLibrary library) {
+  /**
+   * @param secureRandom this will be used to generate the salt.
+   *                     Use FixedSecureRandom for Android, never java.util.SecureRandom.
+   */
+  public PasswordBasedKeyDerivation(SecureRandom secureRandom, NativeCryptoLibrary library) {
+    mSecureRandom = secureRandom;
     mNativeLibrary = library;
     mIterations = DEFAULT_ITERATIONS;
     mKeyLengthInBytes = DEFAULT_KEY_LENGTH;
@@ -103,7 +109,7 @@ public class PasswordBasedKeyDerivation {
     }
     if (mSalt == null) {
       mSalt = new byte[DEFAULT_SALT_LENGTH];
-      new SecureRandom().nextBytes(mSalt);
+      mSecureRandom.nextBytes(mSalt);
     }
     mGeneratedKey = new byte[mKeyLengthInBytes];
     mNativeLibrary.ensureCryptoLoaded();


### PR DESCRIPTION
Encapsulating the fix for SecureRandom will make it easier later to have Conceal outside Android without polluting the code.