### PR TITLE
Formats 6: Remove padding 12->16 (IV is always 12)

### DIFF
--- a/java/com/facebook/crypto/CryptoAlgoV1.java
+++ b/java/com/facebook/crypto/CryptoAlgoV1.java
@@ -82,5 +82,4 @@ public class CryptoAlgoV1 implements CryptoAlgo {
         gcmCipher.updateAad(cipherIDBytes, 1);
         gcmCipher.updateAad(entityBytes, entityBytes.length);
     }
-
 }

--- a/native/crypto/gcm_util.c
+++ b/native/crypto/gcm_util.c
@@ -20,7 +20,7 @@ const int GCM_DECRYPT_MODE = 0;
 static const char* JAVA_GCM_CLASS = "com/facebook/crypto/cipher/NativeGCMCipher";
 
 static const int GCM_KEY_LENGTH_IN_BYTES = 16;
-static const int GCM_IV_LENGTH_IN_BYTES = 16;
+static const int GCM_IV_LENGTH_IN_BYTES = 12;
 
 // Cache field id.
 static jfieldID fieldId = NULL;
@@ -38,14 +38,13 @@ int Init_GCM(JNIEnv* env, jobject obj, jbyteArray key, jbyteArray iv, jint mode)
     return CRYPTO_FAILURE;
   }
 
-  jsize ivLength = (*env)->GetArrayLength(env, iv);
   jbyte* ivBytes = (*env)->GetByteArrayElements(env, iv, NULL);
   if (!ivBytes) {
     (*env)->ReleaseByteArrayElements(env, key, keyBytes, JNI_ABORT);
     return CRYPTO_FAILURE;
   }
 
-  GCM_JNI_CTX* ctx = Create_GCM_JNI_CTX(keyBytes, ivBytes, ivLength);
+  GCM_JNI_CTX* ctx = Create_GCM_JNI_CTX(keyBytes, ivBytes);
   Set_GCM_JNI_CTX(env, obj, ctx);
 
   (*env)->ReleaseByteArrayElements(env, key, keyBytes, JNI_ABORT);
@@ -65,7 +64,7 @@ int Init_GCM(JNIEnv* env, jobject obj, jbyteArray key, jbyteArray iv, jint mode)
   return CRYPTO_SUCCESS;
 }
 
-GCM_JNI_CTX* Create_GCM_JNI_CTX(jbyte* keyBytes, jbyte* ivBytes, jsize ivLength) {
+GCM_JNI_CTX* Create_GCM_JNI_CTX(jbyte* keyBytes, jbyte* ivBytes) {
   GCM_JNI_CTX* ctx = (GCM_JNI_CTX*) malloc(sizeof(GCM_JNI_CTX));
   if (!ctx) {
     return NULL;
@@ -92,17 +91,8 @@ GCM_JNI_CTX* Create_GCM_JNI_CTX(jbyte* keyBytes, jbyte* ivBytes, jsize ivLength)
     return NULL;
   }
 
-  if (ivLength > GCM_IV_LENGTH_IN_BYTES) {
-    ivLength = GCM_IV_LENGTH_IN_BYTES;
-  }
-
   memcpy(ctx->key, keyBytes, GCM_KEY_LENGTH_IN_BYTES);
-  memcpy(ctx->iv, ivBytes, ivLength);
-  if (ivLength < GCM_IV_LENGTH_IN_BYTES) {
-    // pad IV with zeros if provided IV is smaller
-    // this will remove undefined behavior (which worked because the bytes were already the same)
-    memset(ctx->iv + ivLength, 0, GCM_IV_LENGTH_IN_BYTES - ivLength);
-  }
+  memcpy(ctx->iv, ivBytes, GCM_IV_LENGTH_IN_BYTES);
   return ctx;
 }
 

--- a/native/crypto/gcm_util.h
+++ b/native/crypto/gcm_util.h
@@ -17,7 +17,7 @@ void Init_GCM_CTX_Ptr_Field(JNIEnv* env);
 
 int Init_GCM(JNIEnv* env, jobject obj, jbyteArray key, jbyteArray iv, jint mode);
 
-GCM_JNI_CTX* Create_GCM_JNI_CTX(jbyte* keyBytes, jbyte* ivBytes, jsize ivLength);
+GCM_JNI_CTX* Create_GCM_JNI_CTX(jbyte* keyBytes, jbyte* ivBytes);
 
 GCM_JNI_CTX* Get_GCM_JNI_CTX(JNIEnv* env, jobject obj);
 


### PR DESCRIPTION
We can fix the code to pass and copy only 12 bytes as this is this only bytes used by the algorithm (not 16 as we had configured before in `GCM_IV_LENGTH_IN_BYTES`