### PR TITLE
Empty constructor for LinuxPRNGSecureRandom

### DIFF
--- a/java/com/facebook/android/crypto/keychain/SecureRandomFix.java
+++ b/java/com/facebook/android/crypto/keychain/SecureRandomFix.java
@@ -29,6 +29,7 @@ import java.security.Security;
 
 import android.os.Build;
 import com.facebook.crypto.exception.KeyChainException;
+import com.facebook.crypto.proguard.annotations.DoNotStrip;
 
 /**
  * SecureRandom is not really random in android and are biased:
@@ -241,6 +242,14 @@ public class SecureRandomFix {
      * ({@code /dev/urandom}).
      */
     public static class LinuxPRNGSecureRandom extends SecureRandomSpi {
+
+        /**
+         * Explicit constructor to workaround issue #157
+         */
+        @DoNotStrip
+        public LinuxPRNGSecureRandom() {
+          super();
+        }
 
         /*
          * IMPLEMENTATION NOTE: Requests to generate bytes and to mix in a seed


### PR DESCRIPTION
Probably not needed now the random generator provider is not registered. But just in case. See #157 